### PR TITLE
Add `type` to error response, drop "Glide" in GBT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/api-reference/v2/general/errors.mdx
+++ b/api-reference/v2/general/errors.mdx
@@ -10,6 +10,7 @@ All error responses will follow the following format with a top-level `error` ob
 ```json
 {
   "error": {
+    "type": "<error type>",
     "message": "<error message>"
   }
 }
@@ -28,6 +29,7 @@ curl --request GET \
 ```json
 {
   "error": {
+    "type": "request_error",
     "message": "API key not found, or duplicate IN****ID"
   }
 }

--- a/api-reference/v2/general/introduction.mdx
+++ b/api-reference/v2/general/introduction.mdx
@@ -9,7 +9,7 @@ The Glide APIv2 is a RESTful API that allows you to programatically interact wit
 
 ## Functionality
 
-This version of the Glide API **only accesses Glide Big Table data sources**. An attempt to use this API with any other data source will return an error.
+This version of the Glide API **only accesses Big Table data sources**. An attempt to use this API with any other data source will return an error.
 
 ## Location
 
@@ -19,7 +19,7 @@ The Glide API v2 is located at: `https://api.glideapps.com/`.
 
 This Glide API v2 differs from previous versions in that it:
 
-- Is the most performant way to programatically interact with Glide Big Tables
+- Is the most performant way to programatically interact with Big Tables
 - Is capable of ingesting much larger data sets through the use of [stashing](/api-reference/v2/stashing/introduction)
 - Does not require application scoping (i.e., no `appId` is required)
-- Only operates on Glide Big Tables data sources
+- Only operates on Big Tables data sources

--- a/api-reference/v2/tables/get-tables.mdx
+++ b/api-reference/v2/tables/get-tables.mdx
@@ -3,6 +3,6 @@ title: List Tables
 openapi: get /tables
 ---
 
-Get a list of all Glide Big Tables associated with the team of the authenticated user.
+Get a list of all Big Tables associated with the team of the authenticated user.
 
-<Warning>This endpoint only retrieves **Glide Big Table** tables. No other table types will be included in the response, even though they are part of your Glide team.</Warning>
+<Warning>This endpoint only retrieves **Big Table** tables. No other table types will be included in the response, even though they are part of your Glide team.</Warning>

--- a/api-reference/v2/tables/post-table-rows.mdx
+++ b/api-reference/v2/tables/post-table-rows.mdx
@@ -3,7 +3,7 @@ title: Add Rows to Table
 openapi: post /tables/{tableID}/rows
 ---
 
-Add row data to an existing Glide Big Table.
+Add row data to an existing Big Table.
 
 ## Examples
 

--- a/api-reference/v2/tables/post-tables.mdx
+++ b/api-reference/v2/tables/post-tables.mdx
@@ -3,7 +3,7 @@ title: Create Table
 openapi: post /tables
 ---
 
-Create a new Glide Big Table, define its structure, and (optionally) populate it with data.
+Create a new Big Table, define its structure, and (optionally) populate it with data.
 
 ## Examples
 

--- a/api-reference/v2/tables/put-tables.mdx
+++ b/api-reference/v2/tables/put-tables.mdx
@@ -3,7 +3,7 @@ title: Overwrite Table
 openapi: put /tables/{tableID}
 ---
 
-Overwrite an existing Glide Big Table by clearing all rows and adding new data. You can also update the table schema.
+Overwrite an existing Big Table by clearing all rows and adding new data. You can also update the table schema.
 
 <Warning>
 This is a destructive operation that cannot be undone.

--- a/api-reference/v2/tutorials/bulk-import.mdx
+++ b/api-reference/v2/tutorials/bulk-import.mdx
@@ -1,9 +1,9 @@
 ---
 title: Bulk Import
-description: 'Importing large datasets into a Glide Big Table'
+description: 'Importing large datasets into a Big Table'
 ---
 
-When importing large datasets into a Glide Big Table it is necessary to upload the data in stages. This eliminates the volatility of long-running requests and allows for higher performance by parallelizing the upload process. This process is called "stashing".
+When importing large datasets into a Big Table it is necessary to upload the data in stages. This eliminates the volatility of long-running requests and allows for higher performance by parallelizing the upload process. This process is called "stashing".
 
 <Tip>
   Please read our [introduction to stashing](/api-reference/v2/stashing/introduction) to understand how stashing works before looking at bulk imports specifically.
@@ -71,7 +71,7 @@ As an example, the following [stash](/api-reference/v2/stashing/post-stashes-ser
     </Tab>
 </Tabs>
 
-<Note>The trailing parameters of `1` and `2` in the request path are the serial ids which distinguish and order the two uploads within the stash.</Note>
+<Note>The trailing parameters of `1` and `2` in the request path are the serial IDs, which distinguish and order the two uploads within the stash.</Note>
 
 ## Finalize Import
 


### PR DESCRIPTION
- Adds `type` to the error response object in the docs
- Drops "Glide" from "Glide Big Tables" as per https://glideapps.slack.com/archives/C067HJHEDAQ/p1721616252789549?thread_ts=1721615386.969719&cid=C067HJHEDAQ
- Stubs `.gitignore` file