### PR TITLE
Add Github workflow

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,17 @@
+name: Actions
+
+on:
+    pull_request:
+        types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+    check-blocked:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: mheap/github-action-required-labels@v5
+            with:
+                mode: maximum
+                count: 0
+                labels: "blocked:.*"
+                add_comment: true
+                message: "This PR is being prevented from merging because it has one or more of these labels applied: {{ applied }}. "

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,5 +13,6 @@ jobs:
                 mode: maximum
                 count: 0
                 labels: "blocked:.*"
+                use_regex: true
                 add_comment: true
                 message: "This PR is being prevented from merging because it has one or more of these labels applied: {{ applied }}. "


### PR DESCRIPTION
Adds a Github workflow to block PR merging when a label prefixed with `blocked:` is added.

This will be used for taking the API spec changes from the monolith and blocking the docs from shipping until the API changes do.