### PR TITLE
Fix rows field

### DIFF
--- a/api-reference/v2/tables/post-table-rows.mdx
+++ b/api-reference/v2/tables/post-table-rows.mdx
@@ -9,7 +9,7 @@ Add row data to an existing Big Table.
 
 <AccordionGroup>
   <Accordion title="Add Rows Inline">
-    If you want to add a small number of rows to a table, you can do so by providing the data inline in the `rows` field (being sure that row object structure matches the table schema):
+    If you want to add a small number of rows to a table, you can do so by providing the data inline (being sure that row object structure matches the table schema):
 
     ```json
     [


### PR DESCRIPTION
The data is now passed directly without wrapping it in an object in the key `rows`. This commit fixes the accordion not being updated.