### PR TITLE
Add warning about user-specific columns to PUT table endpoint

### DIFF
--- a/api-reference/v2/resources/changelog.mdx
+++ b/api-reference/v2/resources/changelog.mdx
@@ -3,6 +3,10 @@ title: Glide API Changelog
 sidebarTitle: Changelog
 ---
 
+### November 26, 2024
+
+- Added a warning that using the `PUT /tables` endpoint to overwrite a table will clear user-specific columns.
+
 ### November 21, 2024
 
 - Introduced `HEAD /tables/{tableID}/rows` endpoint to retrieve the current version of table data via `ETag` header.

--- a/api-reference/v2/tables/put-tables.mdx
+++ b/api-reference/v2/tables/put-tables.mdx
@@ -5,6 +5,10 @@ openapi: put /tables/{tableID}
 
 Overwrite an existing Big Table by clearing all rows and adding new data.
 
+<Warning>
+There is currently no way to supply values for user-specific columns in the API. Those columns will be cleared when using this endpoint.
+</Warning>
+
 ### Updating the Schema
 
 You can optionally update the table schema at the same time by providing a new schema in the JSON request body. If you do not provide a schema, the existing schema will be used.


### PR DESCRIPTION
The API doesn't currently let you write to user-specific columns, so these will always be cleared out when calling overwrite table. Add a warning about this.